### PR TITLE
Actualización de los valores de tax y UC para materias

### DIFF
--- a/js/carreras/ingenieria-informatica-2017.js
+++ b/js/carreras/ingenieria-informatica-2017.js
@@ -437,7 +437,7 @@ var inginformaticanuevo = [
 		Semestre: "SÉPTIMO SEMESTRE",
 		Asignatura: "Investigación de Operaciones",
 		UC: 5,
-		Tax: "TA-9",
+		Tax: "TA-4",
 	},
 	{
 		Semestre: "SÉPTIMO SEMESTRE",
@@ -497,7 +497,7 @@ var inginformaticanuevo = [
 	{
 		Semestre: "OCTAVO SEMESTRE",
 		Asignatura: "Trabajo de Grado (TG)",
-		UC: 21,
+		UC: 5.25,
 		Tax: "TA-7",
 	},
 ];


### PR DESCRIPTION
Se actualizó la taxonomía de Investigación de Operaciones para reflejar lo que aparece en el plan de estudios del pénsum nuevo. Se actualizó el valor de UC de la tésis para reflejar las UC administrativas (las que se pagarán) y no las académicas. Este cálculo se hizo dado que el valor administrativo de la tésis de Ing Informática es 1/4 de las UC académicas.