### PR TITLE
Actualización de circular julio 2024 a la circular julio 2025

### DIFF
--- a/index.html
+++ b/index.html
@@ -555,8 +555,8 @@
 				<b
 					><a
 						target="_blank"
-						href="https://dstvqyil45ir9.cloudfront.net/wp-content/uploads/2024/07/Circular-Costo-Unidad-Credito-9-de-julio-de-2024.pdf"
-						>CIRCULAR JULIO 2024</a
+						href="https://dstvqyil45ir9.cloudfront.net/wp-content/uploads/2025/07/Circular-Costo-Unidad-Credito-2025-2026.pdf"
+						>CIRCULAR JULIO 2025</a
 					></b
 				>
 

--- a/index.html
+++ b/index.html
@@ -988,6 +988,7 @@
 					<li>Ggap007 (Actualización de la UC y descuento Guayana)</li>
 					<li>Devony Ramirez  (Actualización de la UC)</li>
 					<li>Luis Martin  (roguesquid)</li>
+					<li>Diego Caballero (hasfid)</li>
 				</ul>
 			</p>
 


### PR DESCRIPTION
En este commit lo que hice fue actualizar el link asociado a la circular julio 2024 por la circular publicada este julio 2025, asimismo el titulo que la acompaña.